### PR TITLE
A bit more beginner friendly set up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,87 @@
 Thumbs.db
+
+# Created by https://www.gitignore.io/api/linux,vagrant,vim,python
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+
+### Vagrant ###
+.vagrant/
+
+
+### Vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+    # moar powah
+    vb.cpus = 2
+  end
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+
+    echo "install Ubuntu's ffmpeg fork - libav"
+    sudo apt-get install -y libav-tools
+
+    echo "install openalpr (https://github.com/openalpr/openalpr#binaries)"
+    wget -O - http://deb.openalpr.com/openalpr.gpg.key | sudo apt-key add -
+    echo "deb http://deb.openalpr.com/master/ openalpr main" | sudo tee /etc/apt/sources.list.d/openalpr.list
+    sudo apt-get update
+    sudo apt-get install -y openalpr openalpr-daemon openalpr-utils libopenalpr-dev
+  SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,5 +16,8 @@ Vagrant.configure(2) do |config|
     echo "deb http://deb.openalpr.com/master/ openalpr main" | sudo tee /etc/apt/sources.list.d/openalpr.list
     sudo apt-get update
     sudo apt-get install -y openalpr openalpr-daemon openalpr-utils libopenalpr-dev
+
+    echo "install openalpr python2 bindings"
+    sudo apt-get install -y python-openalpr
   SHELL
 end

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,48 @@
 The scripts contained herein are meant to process the videos and images from public cameras (or
 cameras in public transport) to find A-lane or other statically identifiable violators.
 
+# Install
+
+Tested on Ubuntu 14.04
+
+### Using vagrant
+
+```bash
+vagrant up
+vagrant ssh
+
+# inside vagrant
+cd /vagrant
+```
+
+### Manual install
+
+```bash
+# install Ubuntu's ffmpeg fork - libav
+sudo apt-get install libav-tools
+
+# install openalpr (https://github.com/openalpr/openalpr#binaries)
+wget -O - http://deb.openalpr.com/openalpr.gpg.key | sudo apt-key add -
+echo "deb http://deb.openalpr.com/master/ openalpr main" | sudo tee /etc/apt/sources.list.d/openalpr.list
+sudo apt-get update
+sudo apt-get install openalpr openalpr-daemon openalpr-utils libopenalpr-dev
+```
+
+### Test openalpr
+
+```bash
+wget http://plates.openalpr.com/ea7the.jpg
+alpr -c us ea7the.jpg
+
+wget http://plates.openalpr.com/h786poj.jpg
+alpr -c eu h786poj.jpg
+```
+
 ## Helpers
 
 ### Converting video stream to PNG images
 
 ```bash
+# if you've installed libav-tools, ffmpeg == avconv
 ffmpeg -i /path/to/video.avi -vf fps=1 out/%d.png
 ```
-

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,9 @@ wget -O - http://deb.openalpr.com/openalpr.gpg.key | sudo apt-key add -
 echo "deb http://deb.openalpr.com/master/ openalpr main" | sudo tee /etc/apt/sources.list.d/openalpr.list
 sudo apt-get update
 sudo apt-get install openalpr openalpr-daemon openalpr-utils libopenalpr-dev
+
+# install openalpr python2 bindings
+sudo apt-get install -y python-openalpr
 ```
 
 ### Test openalpr


### PR DESCRIPTION
Tried running `openalpr` on OS X, though unsuccesfully.

So I set up Vagrant environment to use Ubuntu (14.04) and added small installation instructions.

Further steps, IMHO, should be:
- [ ] Add some example footage and/or link to were you can get it.
- [x] Automate openalpr python wrapper installation.
